### PR TITLE
Provide a configurable hostname

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,4 @@ monit_nginx_bin_path: "/usr/sbin/nginx"
 # slack
 monit_slack_channel: "#devops-logs"
 monit_slack_username: "Monit"
+monit_hostname: "{{ ansible_ssh_host }}"

--- a/templates/etc/monit/slack_notifications.sh
+++ b/templates/etc/monit/slack_notifications.sh
@@ -8,7 +8,7 @@
         \"icon_emoji\": \":ghost:\", \
         \"attachments\": [{\
              \"color\": \"warning\", \
-             \"pretext\": \"{{ ansible_hostname }} - {{ ansible_ssh_host }} | $MONIT_DATE\", \
+             \"pretext\": \"{{ ansible_hostname }} - {{ monit_hostname } | $MONIT_DATE\", \
              \"text\": \"$MONIT_SERVICE - $MONIT_DESCRIPTION\" \
         }], \
         \"link_names\": 1 \


### PR DESCRIPTION
Allows the chance for using `ec2metadata --public-ipv4` in EC2
deployments. When baking an image using packer this value is
127.0.0.1 and you cannot tell which server is sending the slack
notfication.