### PR TITLE
Make SSH host keys to check configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,9 @@ monit_nginx_bin_path: "/usr/sbin/nginx"
 monit_slack_channel: "#devops-logs"
 monit_slack_username: "Monit"
 monit_hostname: "{{ ansible_ssh_host }}"
+
+# ssh
+# SSH host keys to check if present
+monit_ssh_host_keys:
+  - name: "sshd_rsa_key"
+    path: "/etc/ssh/ssh_host_rsa_key"

--- a/templates/etc/monit/conf.d/openssh-server
+++ b/templates/etc/monit/conf.d/openssh-server
@@ -8,8 +8,9 @@
    depend on sshd_bin
    depend on sftp_bin
    depend on sshd_rc
-   depend on sshd_rsa_key
-   depend on sshd_dsa_key
+{% for curHostKey in monit_ssh_host_keys %}
+   depend on {{ curHostKey.name }}
+{% endfor %}
 
  check file sshd_bin with path /usr/sbin/sshd
    group sshd
@@ -19,14 +20,12 @@
    group sshd
    include /etc/monit/templates/rootbin
 
- check file sshd_rsa_key with path /etc/ssh/ssh_host_rsa_key
+{% for curHostKey in monit_ssh_host_keys %}
+ check file {{ curHostKey.name }} with path {{ curHostKey.path }}
    group sshd
    include /etc/monit/templates/rootstrict
 
- check file sshd_dsa_key with path /etc/ssh/ssh_host_dsa_key
-   group sshd
-   include /etc/monit/templates/rootstrict
-
+{% endfor %}
  check file sshd_rc with path /etc/ssh/sshd_config
    group sshd
    include /etc/monit/templates/rootrc


### PR DESCRIPTION
Make the list of SSH host keys to check in the OpenSSH file
configurable. This is because some distributions don't come with what
was previously hard-coded in this file.

Don't add the DSA key to the default list since it is no longer present
in all distributions.

Signed-off-by: Jason Rogena <jason@rogena.me>