### PR TITLE
Use PM2 God Process to Search for an Enketo Service

### DIFF
--- a/templates/etc/monit/conf.d/enketo
+++ b/templates/etc/monit/conf.d/enketo
@@ -1,4 +1,4 @@
-check process enketo matching {{ monit_enketo_codebase_path }}/app.js
+check process enketo matching {{ monit_enketo_home }}/.pm2 
 {% if monit_uses_systemd == False %}
    start program = "/bin/bash -lc 'cd {{ monit_enketo_codebase_path }}/ && PM2_HOME={{ monit_enketo_home }}/.pm2 /usr/bin/pm2 app.js -n {{ monit_enketo_user }}'"  as uid {{ monit_enketo_user }} and gid {{ monit_enketo_group }}
    stop program  = "/bin/bash -lc 'cd {{ monit_enketo_codebase_path }}/ && PM2_HOME={{ monit_enketo_home }}/.pm2 /usr/bin/pm2 stop {{ monit_enketo_user }}'"  as uid {{ monit_enketo_user }} and gid {{ monit_enketo_group }}


### PR DESCRIPTION
When running, enketo's path is app_versioned not app.
Use the God process to search for a matching PM2 Enketo service.
To confirm, the best path to use, use `monit procmatch enketo` with pm2-enketo service running.