### PR TITLE
Fix IPSEC monit config

### DIFF
--- a/templates/etc/monit/conf.d/ipsec
+++ b/templates/etc/monit/conf.d/ipsec
@@ -1,4 +1,4 @@
-{% for ipsec_host in monit_ipsec_hosts.items() %}
+{% for ipsec_host in monit_ipsec_hosts %}
 check host {{ ipsec_host.name }} with address {{ ipsec_host.address }}
     start program = "/etc/init.d/ipsec start"
     stop program = "/etc/init.d/ipsec stop"


### PR DESCRIPTION
Replace `monit_ipsec_hosts.items()` with `monit_ipsec_hosts` because
`monit_ipsec_hosts` is a list and not a dictionary