### PR TITLE
Use connection tests to monitor IPSec

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ You can monitor IPSEC connections using the `monit_ipsec_hosts` variable:
 monit_ipsec_hosts:
   - name: ipsec_orange  # name of the IPSEC connection
     address: "10.123.23.2"  # the IPv4, IPv6 or hostname to ping to
+    port: 9999  # port to connect to
+    type: TCP  # either TCP or UDP
     exec_scripts:  # list of names of scripts to execute when ping fails
       - opsgenie-notification
 ```

--- a/templates/etc/monit/conf.d/ipsec
+++ b/templates/etc/monit/conf.d/ipsec
@@ -2,7 +2,10 @@
 check host {{ ipsec_host.name }} with address {{ ipsec_host.address }}
     start program = "/etc/init.d/ipsec start"
     stop program = "/etc/init.d/ipsec stop"
-    if failed ping then restart
+    if failed
+        port {{ ipsec_host.port }}
+        type {{ ipsec_host.type }}
+    then restart
 {% for script in ipsec_host.exec_scripts %}
     if 3 restarts within 3 cycles then exec {{ monit_exec_script_dir }}/{{ script }}
 {% endfor %}


### PR DESCRIPTION
Use of network ping tests to monitor IPSec does not work on some hosts
as ping requests may be blocked by a host